### PR TITLE
In the pyramid binding add an easy way to not trace some route

### DIFF
--- a/zipkin/binding/pyramid/config.py
+++ b/zipkin/binding/pyramid/config.py
@@ -1,4 +1,5 @@
 from pyramid.events import NewRequest
+from pyramid.settings import aslist
 
 from zipkin.config import configure
 from .pyramidhook import wrap_request
@@ -15,6 +16,6 @@ def includeme(config):
                                          'Check the doc.')
         return
     name = settings.get('zipkin.service_name', config.registry.__name__)
+    to_ignore = aslist(settings.get('zipkin.to_ignore', []))
     endpoint = configure(name, settings)
-
-    config.add_subscriber(wrap_request(endpoint), NewRequest)
+    config.add_subscriber(wrap_request(endpoint, to_ignore), NewRequest)

--- a/zipkin/binding/pyramid/pyramidhook.py
+++ b/zipkin/binding/pyramid/pyramidhook.py
@@ -4,9 +4,13 @@ from zipkin.util import int_or_none
 from zipkin.client import log
 
 
-def wrap_request(endpoint):
+def wrap_request(endpoint, to_ignore=[]):
+
     def wrap(event):
         request = event.request
+        if request.path in to_ignore:
+            return
+
         headers = request.headers
         trace = Trace(request.method + ' ' + request.path_qs,
                       int_or_none(headers.get('X-B3-TraceId', None)),


### PR DESCRIPTION
Route like '/monitoring' don't need to be trace, it add noise between the other route which you want to trace.

A new conf key 'zipkin.to_ignore' can be used to list all route that shouldn't be trace.