### PR TITLE
pyramid: migrate to tween view

### DIFF
--- a/zipkin/binding/pyramid/__init__.py
+++ b/zipkin/binding/pyramid/__init__.py
@@ -1,4 +1,4 @@
-from zipkin import __version__
+from zipkin import __version__  # noqa
 
 from .config import includeme
 


### PR DESCRIPTION
This allow to trace requests made on the authentication layer.