### PR TITLE
Hotfix/wraps

### DIFF
--- a/zipkin/api.py
+++ b/zipkin/api.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from .models import Annotation
 from .thread import local
 
@@ -11,6 +13,7 @@ def trace(name):
         return trace(name.__name__)(name)
 
     def func_decorator(func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
 
             try:


### PR DESCRIPTION
In this kind of usage:

```
# Primary nav snippets
@register.inclusion_tag(
    "patterns/molecules/navigation/primarynav.html", takes_context=True
)
@trace
def primarynav(context, *args, **kwargs):
    request = context["request"]
    # Legacy WagtailSettings-based models, left here for easier reversion
    # primarynav = context["settings"]["navigation"]["NavigationSettings"].primary_navigation
    try:
        primarynav = Site.find_for_request(
            request
        ).root_page.specific.menu.localized.primary_navigation
    except AttributeError as exc:
        log.error("Cannot render the primary nav got: %s", exc)
        primarynav = None
    return {
        "primarynav": primarynav,
        "dark_nav": kwargs.get("dark", False),
        "nav_background": kwargs.get("background", None),
        "request": request,
        "svg_loader": context["svg_loader"],
    }
```


Fix this bugs:



```
web_1         | During handling of the above exception, another exception occurred:
web_1         |
web_1         | Traceback (most recent call last):
web_1         |   File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
web_1         |     self.run()
web_1         |   File "/usr/local/lib/python3.7/threading.py", line 870, in run
web_1         |     self._target(*self._args, **self._kwargs)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/utils/autoreload.py", line 64, in wrapper
web_1         |     fn(*args, **kwargs)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 118, in inner_run
web_1         |     self.check(display_num_errors=True)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 423, in check
web_1         |     databases=databases,
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/core/checks/registry.py", line 76, in run_checks
web_1         |     new_errors = check(app_configs=app_configs, databases=databases)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/core/checks/urls.py", line 13, in check_url_config
web_1         |     return check_resolver(resolver)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/core/checks/urls.py", line 23, in check_resolver
web_1         |     return check_method()
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/urls/resolvers.py", line 412, in check
web_1         |     for pattern in self.url_patterns:
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/utils/functional.py", line 48, in __get__
web_1         |     res = instance.__dict__[self.name] = self.func(instance)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/urls/resolvers.py", line 598, in url_patterns
web_1         |     patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/utils/functional.py", line 48, in __get__
web_1         |     res = instance.__dict__[self.name] = self.func(instance)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/urls/resolvers.py", line 591, in urlconf_module
web_1         |     return import_module(self.urlconf_name)
web_1         |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
web_1         |   File "/app/gn/urls.py", line 10, in <module>
web_1         |     from wagtail.admin import urls as wagtailadmin_urls
web_1         |   File "/usr/local/lib/python3.7/site-packages/wagtail/admin/urls/__init__.py", line 85, in <module>
web_1         |     path(f"sprite-{get_sprite_hash()}/", home.sprite, name="wagtailadmin_sprite"),
web_1         |   File "/usr/local/lib/python3.7/site-packages/wagtail/admin/urls/__init__.py", line 76, in get_sprite_hash
web_1         |     content = str(home.sprite(None).content, "utf-8")
web_1         |   File "/usr/local/lib/python3.7/site-packages/wagtail/admin/views/home.py", line 212, in sprite
web_1         |     return HttpResponse(icons())
web_1         |   File "/usr/local/lib/python3.7/site-packages/wagtail/admin/views/home.py", line 207, in icons
web_1         |     _icons_html = render_to_string("wagtailadmin/shared/icons.html", {'icons': all_icons})
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/loader.py", line 61, in render_to_string
web_1         |     template = get_template(template_name, using=using)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/loader.py", line 12, in get_template
web_1         |     engines = _engine_list(using)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/loader.py", line 66, in _engine_list
web_1         |     return engines.all() if using is None else [engines[using]]
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/utils.py", line 90, in all
web_1         |     return [self[alias] for alias in self]
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/utils.py", line 90, in <listcomp>
web_1         |     return [self[alias] for alias in self]
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/utils.py", line 81, in __getitem__
web_1         |     engine = engine_cls(params)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/backends/django.py", line 25, in __init__
web_1         |     options['libraries'] = self.get_templatetag_libraries(libraries)
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/backends/django.py", line 43, in get_templatetag_libraries
web_1         |     libraries = get_installed_libraries()
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/backends/django.py", line 108, in get_installed_libraries
web_1         |     for name in get_package_libraries(pkg):
web_1         |   File "/usr/local/lib/python3.7/site-packages/django/template/backends/django.py", line 121, in get_package_libraries
web_1         |     module = import_module(entry[1])
web_1         |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "/app/gn/project_styleguide/templatetags/navigation_tags.py", line 5, in <module>
web_1         |     override_tag(register, name="primarynav")
web_1         |   File "/usr/local/lib/python3.7/site-packages/pattern_library/monkey_utils.py", line 19, in override_tag
web_1         |     original_tag = register.tags[name]
web_1         | KeyError: 'primarynav'
web_1         |
web_1         | override_tag(register, name="primarynav")
web_1         |   File "/usr/local/lib/python3.7/site-packages/pattern_library/monkey_utils.py", line 19, in override_tag
web_1         |     original_tag = register.tags[name]
web_1         | KeyError: 'primarynav'
gandi-net-cms_web_1 exited with code 1
```