### PR TITLE
Features/context manager

### DIFF
--- a/zipkin/__init__.py
+++ b/zipkin/__init__.py
@@ -1,5 +1,5 @@
 # export the API here
-from .api import trace, get_current_trace, stack_trace
+from .api import trace, get_current_trace, stack_trace, Trace
 
 from .config import configure
 from .thread import local  # XXX remove me from here

--- a/zipkin/api.py
+++ b/zipkin/api.py
@@ -45,20 +45,8 @@ def trace(name):
     def func_decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-
-            try:
-                try:
-                    recording = True
-                    trace = local().child(name)
-                    annotation = Annotation.server_recv()
-                    trace.record(annotation)
-                except Exception:
-                    recording = False
+            with Trace(name):
                 return func(*args, **kwargs)
-            finally:
-                if recording:
-                    trace.record(Annotation.server_send())
-                    local().pop()
 
         return wrapper
 

--- a/zipkin/api.py
+++ b/zipkin/api.py
@@ -3,13 +3,43 @@ from functools import wraps
 from .models import Annotation
 from .thread import local
 
-__all__ = ['trace', 'get_current_trace']
+__all__ = ["trace", "get_current_trace"]
+
+
+class Trace(object):
+    def __init__(self, name):
+        self.name = name
+        self.recording = None
+        self.trace = None
+
+    def __enter__(self):
+
+        try:
+            self.trace = local().child(self.name)
+            annotation = Annotation.server_recv()
+            self.trace.record(annotation)
+            self.recording = True
+        except Exception:
+            self.recording = False
+
+    def __exit__(self, type, value, traceback):
+        if self.recording:
+            self.trace.record(Annotation.server_send())
+            local().pop()
+
+    def __call__(self, func):
+        @wraps(func)
+        def decorated(*args, **kwds):
+            with self:
+                return func(*args, **kwds)
+
+        return decorated
 
 
 def trace(name):
     """ A decorator that trace the decorated function """
 
-    if hasattr(name, '__call__'):
+    if hasattr(name, "__call__"):
         return trace(name.__name__)(name)
 
     def func_decorator(func):
@@ -31,6 +61,7 @@ def trace(name):
                     local().pop()
 
         return wrapper
+
     return func_decorator
 
 


### PR DESCRIPTION
Sometime the `@trace` is not usefull  because some instance is more usefull to get things usefull.

for instance, I've patch django to get some information and I need a template name.

![image](https://user-images.githubusercontent.com/447396/122793034-06d0da00-d2bb-11eb-8244-dbc001c743fe.png)



```
    from zipkin import Trace

    ....

    class Example:
        def render(sef)
            with Trace(self.name):
                 #
                pass 
            
```