### PR TITLE
Rewrite pyramid bindings

### DIFF
--- a/zipkin/binding/pyramid/config.py
+++ b/zipkin/binding/pyramid/config.py
@@ -1,16 +1,7 @@
-from pyramid.events import ContextFound
-from pyramid.tweens import INGRESS
-
-from .pyramidhook import wrap_request
-
-
 def includeme(config):
     """Include the zipkin definitions"""
 
     # Attach the subscriber a couple of times, this allow to start logging as
     # early as possible. Later calls on the same request will enhance the more
     # we proceed through the stack (after authentication, after router, ...)
-    config.add_tween("zipkin.binding.pyramid.pyramidhook.tween_factory", under=INGRESS)
-    zipkin_wrapper = wrap_request(config.registry)
-    if zipkin_wrapper:
-        config.add_subscriber(zipkin_wrapper, ContextFound)
+    config.include(".pyramidhook")

--- a/zipkin/binding/pyramid/pyramidhook.py
+++ b/zipkin/binding/pyramid/pyramidhook.py
@@ -3,7 +3,7 @@ import time
 import logging
 
 from pyramid.tweens import INGRESS
-
+from pyramid.settings import aslist
 
 from zipkin import local
 from zipkin.api import stack_trace
@@ -24,7 +24,15 @@ class AllTraceTweenView(object):
     def configure(cls, settings):
         default_name = "Registry"  # Keep compat with `registry.__name__` ?
         name = settings.get("zipkin.service_name", default_name)
-        cls.endpoint = configure_zk(name, settings)
+
+        bindings = aslist(settings.get("zipkin.bindings", "requests celery xmlrpclib"))
+        cls.endpoint = configure_zk(
+            name,
+            settings,
+            use_requests="requests" in bindings,
+            use_celery="celery" in bindings,
+            use_xmlrpclib="xmlrpclib" in bindings,
+        )
 
     def __init__(self, handler, registry):
         self.handler = handler

--- a/zipkin/binding/pyramid/pyramidhook.py
+++ b/zipkin/binding/pyramid/pyramidhook.py
@@ -1,51 +1,50 @@
+from __future__ import absolute_import
+import time
 import logging
 
+from pyramid.tweens import INGRESS
+
+
 from zipkin import local
+from zipkin.api import stack_trace
 from zipkin.models import Trace, Annotation
 from zipkin.util import int_or_none
 from zipkin.client import log as zipkin_log
-from zipkin.config import configure
+from zipkin.config import configure as configure_zk
 
 
 log = logging.getLogger(__name__)
 
 
-def wrap_request(registry):
-    settings = registry.settings
-    if "zipkin.collector" not in settings:
-        logging.getLogger(__name__).info(
-            "The plugin zipkin.binding.pyramid "
-            "is active but not configured. "
-            "Check the doc."
-        )
-        return
-    default_name = registry.__name__
-    name = settings.get("zipkin.service_name", default_name)
-    endpoint = configure(name, settings)
+class AllTraceTweenView(object):
 
-    def wrap(event):
-        request = event.request
+    endpoint = None
+
+    @classmethod
+    def configure(cls, settings):
+        default_name = "Registry"  # Keep compat with `registry.__name__` ?
+        name = settings.get("zipkin.service_name", default_name)
+        cls.endpoint = configure_zk(name, settings)
+
+    def __init__(self, handler, registry):
+        self.handler = handler
+        self.trace = None
+
+    def track_start_request(self, request):
         headers = request.headers
-        had_trace = False
-        if getattr(request, "trace", None):
-            had_trace = True
 
         trace_name = request.path_qs
         if request.matched_route:
             # we only get a matched route if we've gone through the router.
             trace_name = request.matched_route.pattern
 
-        if had_trace:
-            request.trace.name = request.method + " " + trace_name
-            trace = request.trace
-        else:
-            trace = Trace(
-                request.method + " " + trace_name,
-                int_or_none(headers.get("X-B3-TraceId", None)),
-                int_or_none(headers.get("X-B3-SpanId", None)),
-                int_or_none(headers.get("X-B3-ParentSpanId", None)),
-                endpoint=endpoint,
-            )
+        trace = Trace(
+            request.method + " " + trace_name,
+            int_or_none(headers.get("X-B3-TraceId", None)),
+            int_or_none(headers.get("X-B3-SpanId", None)),
+            int_or_none(headers.get("X-B3-ParentSpanId", None)),
+            endpoint=self.endpoint,
+        )
 
         if "X-B3-TraceId" not in headers:
             log.info("no trace info from request: %s", request.path_qs)
@@ -57,57 +56,93 @@ def wrap_request(registry):
         trace.record(Annotation.string("http.path", request.path_qs))
         log.info("new trace %r", trace.trace_id)
 
-        setattr(request, "trace", trace)
-        if had_trace:
-            # We already had a trace registered for this request, but we got
-            # called again
-            # We should be called twice:
-            #  - For every request (tween view)
-            #  - For every request *after* the router (ContextFound)
-            # Just reset the TraceStack, drop the previous trace, and register
-            # this one instead (which got more information)
-            local().reset()
-        else:
-            request.add_response_callback(add_header_response)
-            request.add_finished_callback(log_response(endpoint))
+        stack_trace(trace)
 
-        local().append(trace)
         trace.record(Annotation.server_recv())
+        self.trace = trace
 
-    return wrap
+    def track_end_request(self, request, response):
+        if self.trace:
+            self.trace.record(Annotation.server_send())
+            log.info("reporting trace %s", self.trace.name)
 
-
-def add_header_response(request, response):
-    if hasattr(request, "trace"):
-        response.headers["Trace-Id"] = str(request.trace.trace_id)
-
-
-def log_response(endpoint):
-    def log_response(request):
-        trace = request.trace
-        trace.record(Annotation.server_send())
-        log.info("reporting trace %s", trace.name)
-
-        zipkin_log(trace)
-        local().reset()
-
-    return log_response
-
-
-class tween_factory(object):
-    def __init__(self, handler, registry):
-        self.handler = handler
-        self.registry = registry
+            response.headers["Trace-Id"] = str(self.trace.trace_id)
+            zipkin_log(self.trace)
+            local().reset()
+            self.trace = None
 
     def __call__(self, request):
-        class ZipkinTweenEvent(object):
-            def __init__(self, request):
-                self.request = request
+        self.track_start_request(request)
+        response = None
+        try:
+            response = self.handler(request)
+        finally:
+            # request.response in case an exception is raised ?
+            self.track_end_request(request, response or request.response)
+        return response or request.response
 
-        zipkin_wrapper = wrap_request(self.registry)
-        if zipkin_wrapper:
-            zipkin_wrapper(ZipkinTweenEvent(request))
 
-        response = self.handler(request)
+class SlowQueryTweenView(AllTraceTweenView):
 
-        return response
+    max_duration = None
+
+    @classmethod
+    def configure(cls, settings):
+        super(SlowQueryTweenView, cls).configure(settings)
+        setting = settings.get("zipkin.slow_log_duration_exceed")
+        if setting is None:
+            log.error(
+                "Missing setting 'zipkin.slow_log_duration_exceed' %r",
+                list(settings.keys()),
+            )
+            return
+        try:
+            cls.max_duration = float(setting)
+        except ValueError:
+            log.error("Invalid setting 'zipkin.slow_log_duration_exceed'")
+
+    def __init__(self, handler, registry):
+        super(SlowQueryTweenView, self).__init__(handler, registry)
+        self.start = None
+
+    def track_start_request(self, request):
+        self.start = time.time()
+        super(SlowQueryTweenView, self).track_start_request(request)
+
+    def track_end_request(self, request, response):
+        if self.max_duration is None:
+            # unconfigure, we don't care
+            return
+        if self.start:
+            duration = time.time() - self.start
+            if duration > self.max_duration:
+                super(SlowQueryTweenView, self).track_end_request(request, response)
+
+
+def includeme(config):
+    """Include the zipkin definitions"""
+
+    # Attach the subscriber a couple of times, this allow to start logging as
+    # early as possible. Later calls on the same request will enhance the more
+    # we proceed through the stack (after authentication, after router, ...)
+
+    settings = config.registry.settings
+    tween_factory = settings.get("zipkin.tween_factory", "all")
+    assert tween_factory in ["all", "slow_query"]
+    if tween_factory == "all":
+        tween_factory = AllTraceTweenView
+    elif tween_factory == "slow_query":
+        tween_factory = SlowQueryTweenView
+    else:
+        log.error(
+            "Invalid value for settings 'zipkin.tween_factory', should be all or slow_query, not %s",
+            tween_factory,
+        )
+        return
+
+    tween_factory.configure(settings)
+
+    config.add_tween(
+        "{}.{}".format(tween_factory.__module__, tween_factory.__name__),
+        under=INGRESS,
+    )

--- a/zipkin/transport/scribeclient.py
+++ b/zipkin/transport/scribeclient.py
@@ -111,9 +111,10 @@ def make_client(
     proto_factory=TBinaryProtocolFactory(),
     trans_factory=TFramedTransportFactory(),
     socket_factory=TNonBlockingSocket,
+    socket_timeout=1000,
 ):
 
-    socket = socket_factory(host, port)
+    socket = socket_factory(host, port, socket_timeout=socket_timeout)
     transport = trans_factory.get_transport(socket)
     protocol = proto_factory.get_protocol(transport)
     transport.open()
@@ -127,6 +128,7 @@ class Client(object):
     _client = None
     _connection_attempts = 0
     _socket_factory = TNonBlockingSocket
+    _socket_timeout = 1000
 
     @classmethod
     def configure(cls, settings, prefix):
@@ -136,6 +138,9 @@ class Client(object):
         if prefix + "transport.async" in settings:
             if settings[prefix + "transport.async"].lower() == "false":
                 cls._socket_factory = TSocket
+
+        if prefix + "transport.socket_timeout" in settings:
+            cls._socket_timeout = int(settings[prefix + "transport.socket_timeout"])
 
     @classmethod
     def get_connection(cls):
@@ -158,6 +163,7 @@ class Client(object):
                     host=cls.host,
                     port=cls.port,
                     socket_factory=cls._socket_factory,
+                    socket_timeout=cls._socket_timeout,
                 )
 
                 cls._connection_attempts = 0


### PR DESCRIPTION
Simplify the tween view, we have complex code, I guess to handle trace when we have 500 errors or something else,

but we want to trace slow query, not 500 errors to me.


Implement the 'slow query' function.

