### PR TITLE
Ensure we never failed for a trace collection failure

### DIFF
--- a/zipkin/client.py
+++ b/zipkin/client.py
@@ -20,4 +20,7 @@ def configure(settings, prefix):
 
 
 def log(trace):
-    Client.log(trace)
+    try:
+        Client.log(trace)
+    except Exception as err:
+        log.error("Unexpected Exception while sending trace: %s", err)


### PR DESCRIPTION
The simplest solution to avoid downtime due to a zipkin error.

Clients implement exception management at a higher level but we may not failed if the error is not managed.