### PR TITLE
Always log the Trace-Id in the header event if not sent to zipkin server

### DIFF
--- a/zipkin/binding/django/middleware.py
+++ b/zipkin/binding/django/middleware.py
@@ -105,8 +105,8 @@ def zk_slow_trace_middleware(get_response):
 
         response = get_response(request)
         duration = time.time() - start
+        add_header_response(response)
         if duration >= settings.ZIPKIN_SLOW_LOG_DURATION_EXCEED:
-            add_header_response(response)
             log_response(trace, response)
         local().reset()
         return response

--- a/zipkin/binding/pyramid/pyramidhook.py
+++ b/zipkin/binding/pyramid/pyramidhook.py
@@ -125,6 +125,8 @@ class SlowQueryTweenView(AllTraceTweenView):
             duration = time.time() - self.start
             if duration > self.max_duration:
                 super(SlowQueryTweenView, self).track_end_request(request, response)
+            else:
+                response.headers["Trace-Id"] = str(self.trace.trace_id)
 
 
 def includeme(config):


### PR DESCRIPTION
Updated for pyramid and django

(Slow query mode not implemented for flask)


Tested on django and pyramid