### PR TITLE
Do not update logger factory without user action

### DIFF
--- a/zipkin/__init__.py
+++ b/zipkin/__init__.py
@@ -5,8 +5,15 @@ from .config import configure
 from .logging import install_logger_factory
 from .thread import local  # XXX remove me from here
 
-install_logger_factory()
 
 __version__ = "0.9.2"
 
-__all__ = ["trace", "Trace", "get_current_trace", "stack_trace", "configure", "local"]
+__all__ = [
+    "Trace",
+    "configure",
+    "get_current_trace",
+    "install_logger_factory",
+    "local",
+    "stack_trace",
+    "trace",
+]

--- a/zipkin/tests/test_logging.py
+++ b/zipkin/tests/test_logging.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from zipkin.api import Trace, get_current_trace, stack_trace
+from zipkin.logging import install_logger_factory
 from zipkin.models import Trace as TraceModel
 
 
@@ -12,6 +13,12 @@ def log_message():
 
 
 class TestLogging(unittest.TestCase):
+    def setUp(self):
+        self.revert = install_logger_factory()
+
+    def tearDown(self):
+        self.revert()
+
     @patch("logging.Logger.handle")
     def test_no_trace_in_stack(self, mock_handle):
         logger = logging.getLogger()


### PR DESCRIPTION
We don't have to install the new root logger without notithing the user..